### PR TITLE
Fix/run command bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,11 +112,6 @@
 					"default": "",
 					"markdownDescription": "An absolute path of an HTML file that contains the project's 'home page' markup. Only the markup inside the `<body>` tags will be used, or if the file contains only a partial HTML page, e.g. `<h2>Cool!</h2>`, the entire contents will be used."
 				},
-				"apexdox.engine.bannerPagePath": {
-					"type": "string",
-					"default": "",
-					"markdownDescription": "An absolute path of an HTML file that contains the project's 'banner' markup. Only the markup inside the `<body>` tags will be used, or if the file contains only a partial HTML page, e.g. `<h2>Cool!</h2>`, the entire contents will be used."
-				},
 				"apexdox.engine.title": {
 					"type": "string",
 					"default": "Apex Documentation",

--- a/src/common/ApexDoxError.ts
+++ b/src/common/ApexDoxError.ts
@@ -43,6 +43,8 @@ class ApexDoxError extends Error {
 
     public static CONFIG_PARSE_ERROR = (fileName: string) =>
         `Failed to parse ${fileName}. Check for syntax errors. See the [documentation](${REPOSITORY}) for more information on ${fileName} config files.`
+
+    public static UNKNOWN_CONFIG_SETTING = (field: string) => `Unknown configuration setting '${field}' found. Please check your settings file.`;
 }
 
 export default ApexDoxError;

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -1,3 +1,5 @@
+import ApexDoxError from './ApexDoxError';
+
 abstract class Validator<T> {
     [key: string]: any;
     protected currentFields: string[];
@@ -9,18 +11,18 @@ abstract class Validator<T> {
     }
 
     /**
-     * Since we're allowing rc and yaml config files, we need to carefully validate configs coming in.
-     * This method will match each config key to an instance method which validates that key. For engine
-     * configs, the 'port' setting is the exception which will be validated only at serveDocs runtime.
-     * This will also take care of deleting any unexpected, rogue config keys.
+     * Since we're allowing rc and yaml config files (e.g. losing helpful intellisense)
+     * we need to carefully validate configs coming in. This method will match each config
+     * key to an instance method which validates that key. For engine configs, the 'port'
+     * setting is the exception which will be validated only at serveDocs runtime. This
+     * will also throw an error if any unexpected, rogue configuration settings are found.
      */
     public validate(): T {
         for (let field of this.currentFields) {
             if (this.validFields.includes(field)) {
                 this[field] && this[field]();
             } else {
-                // @ts-ignore: delete rogue keys found in rc/yaml config
-                delete this.config[field];
+                throw new ApexDoxError(ApexDoxError.UNKNOWN_CONFIG_SETTING(field));
             }
         }
 


### PR DESCRIPTION
Removes deprecated config setting contribution causing bug in latest VS Code versions (was missed when extension was published and should have been removed anyway). 

Also updates the way unknown config settings are handled (useful especially when using .apexdoxrc or apexdox.yaml files).

closes #2 
