### PR TITLE
H3 tag, preserve inline code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 .vscode-test/
 *.vsix
 *.log
+
+# OSX files
+.DS_Store

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -222,6 +222,7 @@ class Utils {
         }
 
         html = html.replace(/<pre class="([a-z\-]+)">\s+<code>/g, '<pre class="$1"><code>');
+        html = html.replace(/<pre>\s+<code class="([a-z\-]+)">/g, '<pre><code class="$1">');
         html = html.replace(/<\/code>\s+<\/pre>/g, '</code></pre>');
         return html;
     }

--- a/src/engine/FileManager.ts
+++ b/src/engine/FileManager.ts
@@ -147,7 +147,7 @@ class FileManager {
      */
     public parseHTMLFile(filePath: string): Option<string, void> {
         if (!filePath.trim()) { return; }
-        const contents = new LineReader(filePath).toString();
+        const contents = new LineReader(filePath).toString(false, "\n");
         if (contents) {
             const startIndex = contents.indexOf('<body>');
             const endIndex = contents.indexOf('</body>');

--- a/src/engine/generators/models/ChildEnumMarkupGenerator.ts
+++ b/src/engine/generators/models/ChildEnumMarkupGenerator.ts
@@ -26,7 +26,7 @@ class ChildEnumMarkupGenerator extends MarkupGenerator<EnumModel> {
 
         markup =
             `<div class="subsection enums">
-                <h3 class="subsection-title enums">Enums</h2>
+                <h3 class="subsection-title enums">Enums</h3>
                 <table class="attributes-table enums">
                     ${markup}
                 </table>

--- a/src/engine/generators/models/PropertyMarkupGenerator.ts
+++ b/src/engine/generators/models/PropertyMarkupGenerator.ts
@@ -25,7 +25,7 @@ class PropertyMarkupGenerator extends MarkupGenerator<PropertyModel> {
 
         markup =
             `<div class="subsection properties ${cModel.name.replace('.', '_')}">
-                <h3 class="subsection-title properties">${cModel.name} Properties</h2>
+                <h3 class="subsection-title properties">${cModel.name} Properties</h3>
                 <table class="attributes-table properties">
                     ${markup}
                 </table>


### PR DESCRIPTION
Update automatic html generation to close H3 tag properly
Parsing inline code in included pages preserves line breaks