### PR TITLE
Fix/html generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 .vscode-test/
 *.vsix
 *.log
+
+# OSX files
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,10 @@ All notable changes to the "apexdox-vs-code" extension will be documented in thi
 - Deprecates `@returns` in favor of the more standard `@return` tag. Thanks to [@berardo](https://github.com/berardo) for the PR.
 - Dependabot security vulnerability updates.
 - **NOTE** that versions 1.1.x, 1.2.x, and 1.3.x were skipped. Please see the 1.4.0 release for a note on this.
+
+## 1.4.1 (04/03/2022)
+
+- Fixes [h2/h2 tag mismatch issue](https://github.com/no-stack-dub-sack/apexdox-vs-code/pull/45/files).
+- Fixes issue where whitespace / newlines in code examples found in user-provided homepages and other supplementary HTML pages was not being correctly preserved.
+- Thanks to [@dschach](https://github.com/dschach) for identifying these issues and opening a PR to fix them.
+- Dependabot security vulnerability updates.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "apexdox-vs-code",
 	"displayName": "ApexDox VS Code",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"publisher": "PeterWeinberg",
 	"author": {
 		"name": "pweinberg"

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -222,6 +222,7 @@ class Utils {
         }
 
         html = html.replace(/<pre class="([a-z\-]+)">\s+<code>/g, '<pre class="$1"><code>');
+        html = html.replace(/<pre>\s+<code class="([a-z\-]+)">/g, '<pre><code class="$1">');
         html = html.replace(/<\/code>\s+<\/pre>/g, '</code></pre>');
         return html;
     }

--- a/src/engine/FileManager.ts
+++ b/src/engine/FileManager.ts
@@ -14,6 +14,7 @@ import rimraf from 'rimraf';
 import { window } from 'vscode';
 import { ISourceEntry, Option, ILunrDocument, IApexDoxMenus } from '..';
 import Utils from '../common/Utils';
+import { EOL } from "os";
 
 class FileManager {
     private path: string;
@@ -147,7 +148,7 @@ class FileManager {
      */
     public parseHTMLFile(filePath: string): Option<string, void> {
         if (!filePath.trim()) { return; }
-        const contents = new LineReader(filePath).toString(false, "\n");
+        const contents = new LineReader(filePath).toString(false, EOL);
         if (contents) {
             const startIndex = contents.indexOf('<body>');
             const endIndex = contents.indexOf('</body>');

--- a/src/engine/FileManager.ts
+++ b/src/engine/FileManager.ts
@@ -147,7 +147,7 @@ class FileManager {
      */
     public parseHTMLFile(filePath: string): Option<string, void> {
         if (!filePath.trim()) { return; }
-        const contents = new LineReader(filePath).toString();
+        const contents = new LineReader(filePath).toString(false, "\n");
         if (contents) {
             const startIndex = contents.indexOf('<body>');
             const endIndex = contents.indexOf('</body>');

--- a/src/engine/generators/models/ChildEnumMarkupGenerator.ts
+++ b/src/engine/generators/models/ChildEnumMarkupGenerator.ts
@@ -26,7 +26,7 @@ class ChildEnumMarkupGenerator extends MarkupGenerator<EnumModel> {
 
         markup =
             `<div class="subsection enums">
-                <h3 class="subsection-title enums">Enums</h2>
+                <h3 class="subsection-title enums">Enums</h3>
                 <table class="attributes-table enums">
                     ${markup}
                 </table>

--- a/src/engine/generators/models/PropertyMarkupGenerator.ts
+++ b/src/engine/generators/models/PropertyMarkupGenerator.ts
@@ -25,7 +25,7 @@ class PropertyMarkupGenerator extends MarkupGenerator<PropertyModel> {
 
         markup =
             `<div class="subsection properties ${cModel.name.replace('.', '_')}">
-                <h3 class="subsection-title properties">${cModel.name} Properties</h2>
+                <h3 class="subsection-title properties">${cModel.name} Properties</h3>
                 <table class="attributes-table properties">
                     ${markup}
                 </table>

--- a/src/test/snapshots/TEST_ArrayUtils.ts
+++ b/src/test/snapshots/TEST_ArrayUtils.ts
@@ -193,42 +193,42 @@ export default `<!DOCTYPE html>
               </div><br />Richard Vanhook<br />Dec 28, 2008
             </div>
             <div class="subsection properties TEST_ArrayUtils">
-              <h3 class="subsection-title properties">TEST_ArrayUtils Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_ArrayUtils Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-
-
-                  </tr>
-                  <tr class="property global">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_ArrayUtils.cls#L26">
-                        EMPTY_STRING_ARRAY
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        global static String[] EMPTY_STRING_ARRAY
-                      </div>
-                    </td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
 
-                  </tr>
-                  <tr class="property global">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_ArrayUtils.cls#L27">
-                        MAX_NUMBER_OF_ELEMENTS_IN_LIST
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        global static Integer MAX_NUMBER_OF_ELEMENTS_IN_LIST
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property global">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_ArrayUtils.cls#L26">
+                      EMPTY_STRING_ARRAY
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      global static String[] EMPTY_STRING_ARRAY
+                    </div>
+                  </td>
 
 
-                  </tr>
-                </table>
+                </tr>
+                <tr class="property global">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_ArrayUtils.cls#L27">
+                      MAX_NUMBER_OF_ELEMENTS_IN_LIST
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      global static Integer MAX_NUMBER_OF_ELEMENTS_IN_LIST
+                    </div>
+                  </td>
+
+
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_ArrayUtils Methods</h3>

--- a/src/test/snapshots/TEST_BotField.ts
+++ b/src/test/snapshots/TEST_BotField.ts
@@ -202,61 +202,61 @@ export default `<!DOCTYPE html>
  }</code></pre>
             </div>
             <div class="subsection properties TEST_BotField">
-              <h3 class="subsection-title properties">TEST_BotField Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_BotField Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Annotations</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Annotations</th>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotField.cls#L26">
-                        linkURL
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String linkURL
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotField.cls#L26">
+                      linkURL
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String linkURL
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotField.cls#L24">
-                        name
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String name
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotField.cls#L24">
+                      name
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String name
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotField.cls#L25">
-                        value
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String value
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotField.cls#L25">
+                      value
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String value
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                </table>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_BotField Methods</h3>

--- a/src/test/snapshots/TEST_BotItem.ts
+++ b/src/test/snapshots/TEST_BotItem.ts
@@ -193,46 +193,46 @@ export default `<!DOCTYPE html>
               </div><br />Salesforce.com<br />Jul 2017
             </div>
             <div class="subsection properties TEST_BotItem">
-              <h3 class="subsection-title properties">TEST_BotItem Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_BotItem Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Annotations</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Annotations</th>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotItem.cls#L15">
-                        linkURL
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String linkURL
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotItem.cls#L15">
+                      linkURL
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String linkURL
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotItem.cls#L14">
-                        name
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String name
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotItem.cls#L14">
+                      name
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String name
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                </table>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_BotItem Methods</h3>

--- a/src/test/snapshots/TEST_BotMessage.ts
+++ b/src/test/snapshots/TEST_BotMessage.ts
@@ -193,106 +193,106 @@ export default `<!DOCTYPE html>
               </div><br />Salesforce.com<br />Jul 2017
             </div>
             <div class="subsection properties TEST_BotMessage">
-              <h3 class="subsection-title properties">TEST_BotMessage Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_BotMessage Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Annotations</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Annotations</th>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L14">
-                        author
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String author
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L14">
+                      author
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String author
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L18">
-                        buttons
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public List&lt;BotMessageButton&gt; buttons
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L18">
+                      buttons
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public List&lt;BotMessageButton&gt; buttons
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L19">
-                        imageURL
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String imageURL
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L19">
+                      imageURL
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String imageURL
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L17">
-                        items
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public List&lt;BotItem&gt; items
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L17">
+                      items
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public List&lt;BotItem&gt; items
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L15">
-                        messageText
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String messageText
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L15">
+                      messageText
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String messageText
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L16">
-                        records
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public List&lt;BotRecord&gt; records
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@AuraEnabled</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_BotMessage.cls#L16">
+                      records
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public List&lt;BotRecord&gt; records
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@AuraEnabled</div>
+                  </td>
 
-                  </tr>
-                </table>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_BotMessage Methods</h3>

--- a/src/test/snapshots/TEST_EnumInner.ts
+++ b/src/test/snapshots/TEST_EnumInner.ts
@@ -184,80 +184,80 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection enums">
-              <h3 class="subsection-title enums">Enums</h2>
-                <table class="attributes-table enums">
+              <h3 class="subsection-title enums">Enums</h3>
+              <table class="attributes-table enums">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Values</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L21">
-                        Days
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Days
-                      </div>
-                    </td>
-                    <td class="enum-values">MONDAY,&nbsp;TUESDAY,&nbsp;WEDNESDAY,&nbsp;THURSDAY,&nbsp;FRIDAY,&nbsp;SATURDAY,&nbsp;SUNDAY</td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Values</th>
+                  <th>Description</th>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L21">
+                      Days
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Days
+                    </div>
+                  </td>
+                  <td class="enum-values">MONDAY,&nbsp;TUESDAY,&nbsp;WEDNESDAY,&nbsp;THURSDAY,&nbsp;FRIDAY,&nbsp;SATURDAY,&nbsp;SUNDAY</td>
 
-                    <td class="attribute-description">
-                      Documentation Engine should parse inner enum values.
-                    </td>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L8">
-                        Months
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Months
-                      </div>
-                    </td>
-                    <td class="enum-values">JAN,&nbsp;FEB,&nbsp;MAR,&nbsp;APR,&nbsp;MAY,&nbsp;JUN,&nbsp;JUL,&nbsp;AUG,&nbsp;SEP,&nbsp;OCT,&nbsp;NOV,&nbsp;DEC</td>
+                  <td class="attribute-description">
+                    Documentation Engine should parse inner enum values.
+                  </td>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L8">
+                      Months
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Months
+                    </div>
+                  </td>
+                  <td class="enum-values">JAN,&nbsp;FEB,&nbsp;MAR,&nbsp;APR,&nbsp;MAY,&nbsp;JUN,&nbsp;JUL,&nbsp;AUG,&nbsp;SEP,&nbsp;OCT,&nbsp;NOV,&nbsp;DEC</td>
 
-                    <td class="attribute-description">
-                      Documentation Engine should parse inner enum values.
-                    </td>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L29">
-                        Numbers
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Numbers
-                      </div>
-                    </td>
-                    <td class="enum-values">ONE,&nbsp;TWO,&nbsp;THREE,&nbsp;FOUR,&nbsp;FIVE</td>
+                  <td class="attribute-description">
+                    Documentation Engine should parse inner enum values.
+                  </td>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L29">
+                      Numbers
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Numbers
+                    </div>
+                  </td>
+                  <td class="enum-values">ONE,&nbsp;TWO,&nbsp;THREE,&nbsp;FOUR,&nbsp;FIVE</td>
 
-                    <td class="attribute-description">
-                      Documentation Engine should parse inner enum values.
-                    </td>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L40">
-                        Rgb
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Rgb
-                      </div>
-                    </td>
-                    <td class="enum-values">RED,&nbsp;GREEN,&nbsp;BLUE</td>
+                  <td class="attribute-description">
+                    Documentation Engine should parse inner enum values.
+                  </td>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_EnumInner.cls#L40">
+                      Rgb
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Rgb
+                    </div>
+                  </td>
+                  <td class="enum-values">RED,&nbsp;GREEN,&nbsp;BLUE</td>
 
-                    <td class="attribute-description">
-                      Documentation Engine should parse inner enum values.
-                    </td>
-                  </tr>
-                </table>
+                  <td class="attribute-description">
+                    Documentation Engine should parse inner enum values.
+                  </td>
+                </tr>
+              </table>
             </div>
           </div>
 

--- a/src/test/snapshots/TEST_JWT.ts
+++ b/src/test/snapshots/TEST_JWT.ts
@@ -193,198 +193,198 @@ export default `<!DOCTYPE html>
               </div><br />Salesforce.com<br />Jul 2017
             </div>
             <div class="subsection properties TEST_JWT">
-              <h3 class="subsection-title properties">TEST_JWT Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_JWT Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-
-
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L11">
-                        alg
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String alg
-                      </div>
-                    </td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L14">
-                        aud
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String aud
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L11">
+                      alg
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String alg
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L19">
-                        cert
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String cert
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L14">
+                      aud
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String aud
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L17">
-                        claims
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public Map&lt;String,String&gt; claims
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L19">
+                      cert
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String cert
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L15">
-                        exp
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String exp
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L17">
+                      claims
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public Map&lt;String,String&gt; claims
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L24">
-                        HS256
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String HS256
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L15">
+                      exp
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String exp
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L16">
-                        iat
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String iat
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L24">
+                      HS256
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String HS256
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L12">
-                        iss
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String iss
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L16">
+                      iat
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String iat
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L26">
-                        NONE
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String NONE
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L12">
+                      iss
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String iss
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L20">
-                        pkcs8
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String pkcs8
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L26">
+                      NONE
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String NONE
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L21">
-                        privateKey
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String privateKey
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L20">
+                      pkcs8
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String pkcs8
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L25">
-                        RS256
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String RS256
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L21">
+                      privateKey
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String privateKey
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L13">
-                        sub
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String sub
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L25">
+                      RS256
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String RS256
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L18">
-                        validFor
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public Integer validFor
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L13">
+                      sub
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String sub
+                    </div>
+                  </td>
 
 
-                  </tr>
-                </table>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_JWT.cls#L18">
+                      validFor
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public Integer validFor
+                    </div>
+                  </td>
+
+
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_JWT Methods</h3>

--- a/src/test/snapshots/TEST_LIFXController.ts
+++ b/src/test/snapshots/TEST_LIFXController.ts
@@ -187,29 +187,29 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_LIFXController">
-              <h3 class="subsection-title properties">TEST_LIFXController Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_LIFXController Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-
-
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_LIFXController.cls#L9">
-                        settings
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Dreamhouse_Settings__c settings
-                      </div>
-                    </td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
 
-                  </tr>
-                </table>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_LIFXController.cls#L9">
+                      settings
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Dreamhouse_Settings__c settings
+                    </div>
+                  </td>
+
+
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_LIFXController Methods</h3>

--- a/src/test/snapshots/TEST_NestedClasses.ts
+++ b/src/test/snapshots/TEST_NestedClasses.ts
@@ -187,64 +187,64 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_NestedClasses">
-              <h3 class="subsection-title properties">TEST_NestedClasses Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_NestedClasses Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
-                    <th>Description</th>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L25">
-                        m
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final String m
-                      </div>
-                    </td>
-
-
-                    <td class="attribute-description">
-                      Member variable for outer class
-                    </td>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L8">
-                        MY_INT
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer MY_INT
-                      </div>
-                    </td>
+                  <th>Description</th>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L25">
+                      m
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final String m
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
-                      Static final variable (constant) – outer class level only
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L14">
-                        sharedState
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static String sharedState
-                      </div>
-                    </td>
+                  <td class="attribute-description">
+                    Member variable for outer class
+                  </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L8">
+                      MY_INT
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer MY_INT
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
-                      Non-final static variable - use this to communicate state across triggers within a single request)
-                    </td>
-                  </tr>
-                </table>
+                  <td class="attribute-description">
+                    Static final variable (constant) – outer class level only
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L14">
+                      sharedState
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static String sharedState
+                    </div>
+                  </td>
+
+
+                  <td class="attribute-description">
+                    Non-final static variable - use this to communicate state across triggers within a single request)
+                  </td>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_NestedClasses Methods</h3>
@@ -565,64 +565,64 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_NestedClasses_InnerClass">
-              <h3 class="subsection-title properties">TEST_NestedClasses.InnerClass Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_NestedClasses.InnerClass Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
-                    <th>Description</th>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L67">
-                        i
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final Integer i
-                      </div>
-                    </td>
-
-
-                    <td class="attribute-description">
-                      Inline initialization (happens after the block above executes)
-                    </td>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L58">
-                        s
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final String s
-                      </div>
-                    </td>
+                  <th>Description</th>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L67">
+                      i
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final Integer i
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
+                    Inline initialization (happens after the block above executes)
+                  </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L58">
+                      s
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final String s
+                    </div>
+                  </td>
 
-                    </td>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L59">
-                        s2
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final String s2
-                      </div>
-                    </td>
+
+                  <td class="attribute-description">
+
+                  </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L59">
+                      s2
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final String s2
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
 
-                    </td>
-                  </tr>
-                </table>
+                  </td>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_NestedClasses.InnerClass Constructors</h3>
@@ -770,32 +770,32 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_NestedClasses_MyException">
-              <h3 class="subsection-title properties">TEST_NestedClasses.MyException Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_NestedClasses.MyException Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
-                    <th>Description</th>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L138">
-                        d
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public Double d
-                      </div>
-                    </td>
+                  <th>Description</th>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_NestedClasses.cls#L138">
+                      d
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public Double d
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
-                      Exception class member variable
-                    </td>
-                  </tr>
-                </table>
+                  <td class="attribute-description">
+                    Exception class member variable
+                  </td>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_NestedClasses.MyException Constructors</h3>

--- a/src/test/snapshots/TEST_Properties.ts
+++ b/src/test/snapshots/TEST_Properties.ts
@@ -184,198 +184,198 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_Properties">
-              <h3 class="subsection-title properties">TEST_Properties Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_Properties Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-
-
-                  </tr>
-                  <tr class="property protected">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L12">
-                        outer_eight
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        protected static Map&lt;String,String&gt; outer_eight
-                      </div>
-                    </td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
 
-                  </tr>
-                  <tr class="property protected">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L15">
-                        outer_eleven
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        protected Set&lt;String&gt; outer_eleven
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property protected">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L12">
+                      outer_eight
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      protected static Map&lt;String,String&gt; outer_eight
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L9">
-                        outer_five
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String outer_five
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property protected">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L15">
+                      outer_eleven
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      protected Set&lt;String&gt; outer_eleven
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L8">
-                        outer_four
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String outer_four
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L9">
+                      outer_five
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String outer_five
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L29">
-                        outer_fourteen
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private Integer outer_fourteen
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L8">
+                      outer_four
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String outer_four
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property protected">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L13">
-                        outer_nine
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        protected Map&lt;String,String&gt; outer_nine
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L29">
+                      outer_fourteen
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private Integer outer_fourteen
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L5">
-                        outer_one
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String outer_one
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property protected">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L13">
+                      outer_nine
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      protected Map&lt;String,String&gt; outer_nine
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L11">
-                        outer_seven
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String outer_seven
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L5">
+                      outer_one
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String outer_one
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L10">
-                        outer_six
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String outer_six
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L11">
+                      outer_seven
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String outer_seven
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property protected">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L14">
-                        outer_ten
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        protected List&lt;Integer&gt; outer_ten
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L10">
+                      outer_six
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String outer_six
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L23">
-                        outer_thirteen
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String outer_thirteen
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property protected">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L14">
+                      outer_ten
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      protected List&lt;Integer&gt; outer_ten
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L7">
-                        outer_three
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static String outer_three
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L23">
+                      outer_thirteen
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String outer_thirteen
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L17">
-                        outer_twelve
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String outer_twelve
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L7">
+                      outer_three
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static String outer_three
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L6">
-                        outer_two
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String outer_two
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L17">
+                      outer_twelve
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String outer_twelve
+                    </div>
+                  </td>
 
 
-                  </tr>
-                </table>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L6">
+                      outer_two
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String outer_two
+                    </div>
+                  </td>
+
+
+                </tr>
+              </table>
             </div>
           </div>
 
@@ -398,80 +398,80 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_Properties_InnerOne">
-              <h3 class="subsection-title properties">TEST_Properties.InnerOne Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_Properties.InnerOne Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
-                    <th>Description</th>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L46">
-                        inner_four
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String inner_four
-                      </div>
-                    </td>
-
-
-                    <td class="attribute-description">
-
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L43">
-                        inner_one
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String inner_one
-                      </div>
-                    </td>
+                  <th>Description</th>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L46">
+                      inner_four
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String inner_four
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
-                      Description for inner_one
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L45">
-                        inner_three
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static String inner_three
-                      </div>
-                    </td>
+                  <td class="attribute-description">
+
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L43">
+                      inner_one
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String inner_one
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
+                    Description for inner_one
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L45">
+                      inner_three
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static String inner_three
+                    </div>
+                  </td>
 
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L44">
-                        inner_two
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String inner_two
-                      </div>
-                    </td>
+
+                  <td class="attribute-description">
+
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L44">
+                      inner_two
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String inner_two
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
 
-                    </td>
-                  </tr>
-                </table>
+                  </td>
+                </tr>
+              </table>
             </div>
           </div>
 
@@ -494,82 +494,82 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_Properties_InnerThree">
-              <h3 class="subsection-title properties">TEST_Properties.InnerThree Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_Properties.InnerThree Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Annotations</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L63">
-                        inner_four
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String inner_four
-                      </div>
-                    </td>
-                    <td></td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Annotations</th>
+                  <th>Description</th>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L63">
+                      inner_four
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String inner_four
+                    </div>
+                  </td>
+                  <td></td>
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
 
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L59">
-                        inner_one
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String inner_one
-                      </div>
-                    </td>
-                    <td></td>
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L59">
+                      inner_one
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String inner_one
+                    </div>
+                  </td>
+                  <td></td>
 
-                    <td class="attribute-description">
-                      Description for inner_one
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L62">
-                        inner_three
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static String inner_three
-                      </div>
-                    </td>
-                    <td></td>
+                  <td class="attribute-description">
+                    Description for inner_one
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L62">
+                      inner_three
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static String inner_three
+                    </div>
+                  </td>
+                  <td></td>
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
 
-                    </td>
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L61">
-                        inner_two
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String inner_two
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@TestVisible</div>
-                    </td>
+                  </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L61">
+                      inner_two
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String inner_two
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@TestVisible</div>
+                  </td>
 
-                    <td class="attribute-description">
+                  <td class="attribute-description">
 
-                    </td>
-                  </tr>
-                </table>
+                  </td>
+                </tr>
+              </table>
             </div>
           </div>
 
@@ -592,70 +592,70 @@ export default `<!DOCTYPE html>
               </div>
             </div>
             <div class="subsection properties TEST_Properties_InnerTwo">
-              <h3 class="subsection-title properties">TEST_Properties.InnerTwo Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_Properties.InnerTwo Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Annotations</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Annotations</th>
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L54">
-                        inner_four
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private String inner_four
-                      </div>
-                    </td>
-                    <td></td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L54">
+                      inner_four
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private String inner_four
+                    </div>
+                  </td>
+                  <td></td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L51">
-                        inner_one
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public String inner_one
-                      </div>
-                    </td>
-                    <td>
-                      <div class="prop-annotations">@TestVisible</div>
-                    </td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L51">
+                      inner_one
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public String inner_one
+                    </div>
+                  </td>
+                  <td>
+                    <div class="prop-annotations">@TestVisible</div>
+                  </td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L53">
-                        inner_three
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static String inner_three
-                      </div>
-                    </td>
-                    <td></td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L53">
+                      inner_three
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static String inner_three
+                    </div>
+                  </td>
+                  <td></td>
 
-                  </tr>
-                  <tr class="property public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L52">
-                        inner_two
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public static final String inner_two
-                      </div>
-                    </td>
-                    <td></td>
+                </tr>
+                <tr class="property public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_Properties.cls#L52">
+                      inner_two
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public static final String inner_two
+                    </div>
+                  </td>
+                  <td></td>
 
-                  </tr>
-                </table>
+                </tr>
+              </table>
             </div>
           </div>
 

--- a/src/test/snapshots/TEST_SlackOpportunityPublisher.ts
+++ b/src/test/snapshots/TEST_SlackOpportunityPublisher.ts
@@ -193,108 +193,108 @@ export default `<!DOCTYPE html>
               </div><br />Salesforce.com<br />Jul 2017
             </div>
             <div class="subsection properties TEST_SlackOpportunityPublisher">
-              <h3 class="subsection-title properties">TEST_SlackOpportunityPublisher Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_SlackOpportunityPublisher Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
-                    <th>Description</th>
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L17">
-                        slackURL
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final String slackURL
-                      </div>
-                    </td>
+                  <th>Description</th>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L17">
+                      slackURL
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final String slackURL
+                    </div>
+                  </td>
 
 
-                    <td class="attribute-description">
-                      The slack URL to use for publishing.
-                    </td>
-                  </tr>
-                </table>
+                  <td class="attribute-description">
+                    The slack URL to use for publishing.
+                  </td>
+                </tr>
+              </table>
             </div>
             <div class="subsection enums">
-              <h3 class="subsection-title enums">Enums</h2>
-                <table class="attributes-table enums">
+              <h3 class="subsection-title enums">Enums</h3>
+              <table class="attributes-table enums">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-                    <th>Values</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L55">
-                        Days
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Days
-                      </div>
-                    </td>
-                    <td class="enum-values">MONDAY,&nbsp;TUESDAY,&nbsp;WEDNESDAY,&nbsp;THURSDAY,&nbsp;FRIDAY,&nbsp;SATURDAY,&nbsp;SUNDAY</td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
+                  <th>Values</th>
+                  <th>Description</th>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L55">
+                      Days
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Days
+                    </div>
+                  </td>
+                  <td class="enum-values">MONDAY,&nbsp;TUESDAY,&nbsp;WEDNESDAY,&nbsp;THURSDAY,&nbsp;FRIDAY,&nbsp;SATURDAY,&nbsp;SUNDAY</td>
 
-                    <td class="attribute-description">
-                      An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They will be presented in a table and can only have description&#39;s, like properties.
-                    </td>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L40">
-                        Months
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Months
-                      </div>
-                    </td>
-                    <td class="enum-values">JANUARY,&nbsp;FEBRUARY,&nbsp;MARCH,&nbsp;APRIL,&nbsp;MAY,&nbsp;JUNE,&nbsp;JULY,&nbsp;AUGUST,&nbsp;SEPTEMBER,&nbsp;OCTOBER,&nbsp;NOVEMBER,&nbsp;DECEMBER</td>
+                  <td class="attribute-description">
+                    An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They will be presented in a table and can only have description&#39;s, like properties.
+                  </td>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L40">
+                      Months
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Months
+                    </div>
+                  </td>
+                  <td class="enum-values">JANUARY,&nbsp;FEBRUARY,&nbsp;MARCH,&nbsp;APRIL,&nbsp;MAY,&nbsp;JUNE,&nbsp;JULY,&nbsp;AUGUST,&nbsp;SEPTEMBER,&nbsp;OCTOBER,&nbsp;NOVEMBER,&nbsp;DECEMBER</td>
 
-                    <td class="attribute-description">
-                      An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They can only have description&#39;s, like properties. ApexDoc2 Should be able to handle to wonky way this enum is written in code.
-                    </td>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L65">
-                        Numbers
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Numbers
-                      </div>
-                    </td>
-                    <td class="enum-values">ONE,&nbsp;TWO,&nbsp;THREE,&nbsp;FOUR,&nbsp;FIVE</td>
+                  <td class="attribute-description">
+                    An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They can only have description&#39;s, like properties. ApexDoc2 Should be able to handle to wonky way this enum is written in code.
+                  </td>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L65">
+                      Numbers
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Numbers
+                    </div>
+                  </td>
+                  <td class="enum-values">ONE,&nbsp;TWO,&nbsp;THREE,&nbsp;FOUR,&nbsp;FIVE</td>
 
-                    <td class="attribute-description">
-                      An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They will be presented in a table and can only have description&#39;s, like properties.
-                    </td>
-                  </tr>
-                  <tr class="enum public">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L78">
-                        Rgb
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        public enum Rgb
-                      </div>
-                    </td>
-                    <td class="enum-values">RED,&nbsp;GREEN,&nbsp;BLUE</td>
+                  <td class="attribute-description">
+                    An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They will be presented in a table and can only have description&#39;s, like properties.
+                  </td>
+                </tr>
+                <tr class="enum public">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L78">
+                      Rgb
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      public enum Rgb
+                    </div>
+                  </td>
+                  <td class="enum-values">RED,&nbsp;GREEN,&nbsp;BLUE</td>
 
-                    <td class="attribute-description">
-                      An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They will be presented in a table and can only have description&#39;s, like properties.
-                    </td>
-                  </tr>
-                </table>
+                  <td class="attribute-description">
+                    An inner enum added to demonstrate how ApexDox VS Code handles inner enums. They will be presented in a table and can only have description&#39;s, like properties.
+                  </td>
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_SlackOpportunityPublisher Methods</h3>
@@ -365,55 +365,55 @@ export default `<!DOCTYPE html>
  System.enqueueJob(new QueueablePushCall(&#39;https://someurl.com&#39;, &#39;POST&#39;, body));</code></pre>
             </div>
             <div class="subsection properties TEST_SlackOpportunityPublisher_QueueableSlackCall">
-              <h3 class="subsection-title properties">TEST_SlackOpportunityPublisher.QueueableSlackCall Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_SlackOpportunityPublisher.QueueableSlackCall Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-
-
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L96">
-                        body
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final String body
-                      </div>
-                    </td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L95">
-                        method
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final String method
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L96">
+                      body
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final String body
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L94">
-                        url
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private final String url
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L95">
+                      method
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final String method
+                    </div>
+                  </td>
 
 
-                  </tr>
-                </table>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_SlackOpportunityPublisher.cls#L94">
+                      url
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private final String url
+                    </div>
+                  </td>
+
+
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_SlackOpportunityPublisher.QueueableSlackCall Constructors</h3>

--- a/src/test/snapshots/TEST_StopWatch.ts
+++ b/src/test/snapshots/TEST_StopWatch.ts
@@ -193,146 +193,146 @@ export default `<!DOCTYPE html>
               </div><br />Richard Vanhook<br />Dec 28, 2008
             </div>
             <div class="subsection properties TEST_StopWatch">
-              <h3 class="subsection-title properties">TEST_StopWatch Properties</h2>
-                <table class="attributes-table properties">
+              <h3 class="subsection-title properties">TEST_StopWatch Properties</h3>
+              <table class="attributes-table properties">
 
-                  <tr>
-                    <th>Name</th>
-                    <th>Signature</th>
-
-
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L36">
-                        runningState
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private Integer runningState
-                      </div>
-                    </td>
+                <tr>
+                  <th>Name</th>
+                  <th>Signature</th>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L37">
-                        splitState
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private Integer splitState
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L36">
+                      runningState
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private Integer runningState
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L38">
-                        startTime
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private Long startTime
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L37">
+                      splitState
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private Integer splitState
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L28">
-                        STATE_RUNNING
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer STATE_RUNNING
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L38">
+                      startTime
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private Long startTime
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L34">
-                        STATE_SPLIT
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer STATE_SPLIT
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L28">
+                      STATE_RUNNING
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer STATE_RUNNING
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L29">
-                        STATE_STOPPED
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer STATE_STOPPED
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L34">
+                      STATE_SPLIT
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer STATE_SPLIT
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L30">
-                        STATE_SUSPENDED
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer STATE_SUSPENDED
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L29">
+                      STATE_STOPPED
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer STATE_STOPPED
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L33">
-                        STATE_UNSPLIT
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer STATE_UNSPLIT
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L30">
+                      STATE_SUSPENDED
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer STATE_SUSPENDED
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L27">
-                        STATE_UNSTARTED
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private static final Integer STATE_UNSTARTED
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L33">
+                      STATE_UNSPLIT
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer STATE_UNSPLIT
+                    </div>
+                  </td>
 
 
-                  </tr>
-                  <tr class="property private">
-                    <td class="attribute-name">
-                      <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L39">
-                        stopTime
-                      </a></td>
-                    <td>
-                      <div class="attribute-signature">
-                        private Long stopTime
-                      </div>
-                    </td>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L27">
+                      STATE_UNSTARTED
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private static final Integer STATE_UNSTARTED
+                    </div>
+                  </td>
 
 
-                  </tr>
-                </table>
+                </tr>
+                <tr class="property private">
+                  <td class="attribute-name">
+                    <a target="_blank" rel="noopener noreferrer" title="Go to source" class="source-link" href="https://somefakeurl.com/TEST_StopWatch.cls#L39">
+                      stopTime
+                    </a></td>
+                  <td>
+                    <div class="attribute-signature">
+                      private Long stopTime
+                    </div>
+                  </td>
+
+
+                </tr>
+              </table>
             </div>
             <div class="subsection methods">
               <h3 class="subsection-title methods">TEST_StopWatch Methods</h3>

--- a/src/test/snapshots/index.ts
+++ b/src/test/snapshots/index.ts
@@ -182,7 +182,7 @@ export default `<!DOCTYPE html>
             <pre class="code-example"><code>@AuraEnabled
 public static void someMethod() {
     List&lt;BotField&gt; fields = new List&lt;BotField&gt;();
-    System.debug('Some debug statement')
+    System.debug('Some debug statement');
 }</code></pre>
           </div>
 

--- a/src/test/snapshots/index.ts
+++ b/src/test/snapshots/index.ts
@@ -165,14 +165,29 @@ export default `<!DOCTYPE html>
       <tr>
         <td class="doc-page">
           <h2 class='section-title'>Home</h2>
-          <h2>
-            Project Home
-          </h2>
+          <h1>Test Docs Homepage</h1>
+
           <p>
-            Use the <code class="code-inline">apexdox.homePagePath</code> setting
-            to point to an HTML file that contains details about your project.
-            The body of the HTML will show up here instead of this default!
+            <strong>IMPORTANT:</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+            labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+            commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
           </p>
+
+          <h2>Subtitle</h2>
+
+          <p>This code should be formatted correctly:</p>
+
+          <div>
+            <pre class="code-example"><code>@AuraEnabled
+public static void someMethod() {
+    List&lt;BotField&gt; fields = new List&lt;BotField&gt;();
+    System.debug('Some debug statement')
+}</code></pre>
+          </div>
+
+          <p>Fin.</p>
+
         </td>
       </tr>
       <tr>

--- a/src/test/suites/document.suite.ts
+++ b/src/test/suites/document.suite.ts
@@ -93,5 +93,20 @@ export const createDocumentSuite = (files: ITestFile[]) => {
             const deprecated = $('.method-subtitle-description').toArray().filter(el => $(el).text().trim() === 'Works over multiple lines (deprecated).');
             assert.equal($(deprecated).text().trim(), 'Works over multiple lines (deprecated).', 'deprecated value does not match expected multi-line value');
         });
+
+        test('Should preserver whitespace and newlines for supplementary page code examples', function() {
+            const indexHtml = last(only(files, ['index.html'], 'name'));
+            let $ = cheerio.load(indexHtml.snapshot);
+
+            const actual = $("code").toArray().reduce((acc, el) => acc + $(el).text(), "");
+
+            const expected = `@AuraEnabled
+public static void someMethod() {
+    List<BotField> fields = new List<BotField>();
+    System.debug('Some debug statement');
+}`;
+
+            assert.equal(actual, expected, "Example code does not match expected value");
+        });
     });
 };

--- a/src/test/test-proj/.vscode/settings.json
+++ b/src/test/test-proj/.vscode/settings.json
@@ -17,7 +17,7 @@
         "*Test.cls",
         "TEST_ExcludeMe.cls"
     ],
-	"apexdox.engine.homePagePath": "",
+	"apexdox.engine.homePagePath": "${workspaceFolder}/src/Homepage.html",
 	"apexdox.engine.scope": [
         "public",
         "private",

--- a/src/test/test-proj/src/Homepage.html
+++ b/src/test/test-proj/src/Homepage.html
@@ -1,0 +1,24 @@
+<h1>Test Docs Homepage</h1>
+
+<p>
+    <strong>IMPORTANT:</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut 
+    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</p>
+
+<h2>Subtitle</h2>
+
+<p>This code should be formatted correctly:</p>
+
+<div>
+    <pre class="code-example">
+        <code>@AuraEnabled
+public static void someMethod() {
+    List&lt;BotField&gt; fields = new List&lt;BotField&gt;();
+    System.debug('Some debug statement');
+}</code>
+    </pre>
+</div>
+
+<p>Fin.</p>


### PR DESCRIPTION
builds on the work started in #45 by @dschach 

- Fixes [h2/h2 tag mismatch issue](https://github.com/no-stack-dub-sack/apexdox-vs-code/pull/45/files).
- Fixes issue where whitespace / newlines in code examples found in user-provided homepages and other supplementary HTML pages was not being correctly preserved.
- Updates snapshots to reflect latest changes
- Adds new test to cover functionality that is fixed with this PR (code examples in supplementary content)