### PR TITLE
Expanded HTML tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,10 @@ All notable changes to the "apexdox-vs-code" extension will be documented in thi
 
 ## 1.4.2 (09/23/2022)
 
-- Added support for `<b></b>`, `<li></li>` and `<ul></ul>` tags in comment blocks
+- Added support for a few additional html tags in comments blocks:
+    * `<b></b>`
+    * `<i></i>`
+    * `<u></u>`
+    * `<s></s>`            
+    * `<li></li>`
+    * `<ul></ul>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,7 @@ All notable changes to the "apexdox-vs-code" extension will be documented in thi
 - Fixes issue where whitespace / newlines in code examples found in user-provided homepages and other supplementary HTML pages was not being correctly preserved.
 - Thanks to [@dschach](https://github.com/dschach) for identifying these issues and opening a PR to fix them.
 - Dependabot security vulnerability updates.
+
+## 1.4.2 (09/23/2022)
+
+- Added support for `<b></b>`, `<li></li>` and `<ul></ul>` tags in comment blocks

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "apexdox-vs-code",
 	"displayName": "ApexDox VS Code",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"publisher": "PeterWeinberg",
 	"author": {
 		"name": "pweinberg"

--- a/src/engine/generators/GeneratorUtils.ts
+++ b/src/engine/generators/GeneratorUtils.ts
@@ -25,8 +25,20 @@ class GeneratorUtils {
         }
 
         // unescape <br> tags, we want to keep these
-        result = result.replace(/&lt;br\s?\/?&gt;/g, '<br>');
+        result = result.replace(/&lt;br\s?\/?&gt;/g, '<br>');        
+        
+        // unescape <b> and </b> tags, we want to keep these (ce 20220923)
+        result = result.replace(/&lt;b&gt;/g, '<b>');        
+        result = result.replace(/&lt;\/b&gt;/g, '</b>');        
 
+        // unescape <li> and </li> tags, we want to keep these (ce 20220923)
+        result = result.replace(/&lt;li&gt;/g, '<li>');        
+        result = result.replace(/&lt;\/li&gt;/g, '</li>');                
+
+        // unescape <ul> and </ul> tags, we want to keep these (ce 20220923)
+        result = result.replace(/&lt;ul&gt;/g, '<ul>');        
+        result = result.replace(/&lt;\/ul&gt;/g, '</ul>');   
+        
         return result;
     }
 

--- a/src/engine/generators/GeneratorUtils.ts
+++ b/src/engine/generators/GeneratorUtils.ts
@@ -31,6 +31,18 @@ class GeneratorUtils {
         result = result.replace(/&lt;b&gt;/g, '<b>');        
         result = result.replace(/&lt;\/b&gt;/g, '</b>');        
 
+        // unescape <i> and </i> tags, we want to keep these (ce 20220923)
+        result = result.replace(/&lt;i&gt;/g, '<i>');        
+        result = result.replace(/&lt;\/i&gt;/g, '</i>');  
+        
+        // unescape <s> and </s> tags, we want to keep these (ce 20220923)
+        result = result.replace(/&lt;s&gt;/g, '<s>');        
+        result = result.replace(/&lt;\/s&gt;/g, '</s>');          
+        
+        // unescape <u> and </u> tags, we want to keep these (ce 20220923)
+        result = result.replace(/&lt;u&gt;/g, '<u>');        
+        result = result.replace(/&lt;\/u&gt;/g, '</u>');                
+
         // unescape <li> and </li> tags, we want to keep these (ce 20220923)
         result = result.replace(/&lt;li&gt;/g, '<li>');        
         result = result.replace(/&lt;\/li&gt;/g, '</li>');                


### PR DESCRIPTION
Added more html tag support in comment blocks - for now just `<b></b>`, `<li></li>` and `<ul></ul>`.