### PR TITLE
fix: open docs bug

### DIFF
--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -203,6 +203,7 @@ class Utils {
 
             window.showErrorMessage(`Workspace variable in path '${path}' could not be resolved.`);
         }
+
         return {} as never;
     }
 

--- a/src/engine/server.ts
+++ b/src/engine/server.ts
@@ -14,11 +14,9 @@ const listening = (port: number) => `ApexDox VS Code server listening on port ${
 const error = (dir: string) =>  `No index.html file to serve in directory: ${dir}. Did you run 'ApexDox: Run' first?`;
 
 export default async function createDocServer(targetDirectory: string, docsTitle: string, port: number) {
-    const resolvedTarget = Utils.resolveWorkspaceFolder(targetDirectory).resolvedPath;
+    if (existsSync(resolve(targetDirectory, 'index.html'))) {
 
-    if (existsSync(resolve(resolvedTarget, 'index.html'))) {
-
-        const file = new _static.Server(resolvedTarget, { cache: false }); // do not cache files
+        const file = new _static.Server(targetDirectory, { cache: false }); // do not cache files
         closeServer() && (server = http.createServer((request, response) => {
             request.addListener('end', () => {
                 file.serve(request, response);
@@ -29,7 +27,7 @@ export default async function createDocServer(targetDirectory: string, docsTitle
         await open(`http://localhost:${port}/index.html`);
         window.setStatusBarMessage(success(docsTitle));
     } else {
-        window.showErrorMessage(error(resolvedTarget));
+        window.showErrorMessage(error(targetDirectory));
     }
 }
 


### PR DESCRIPTION
Return type for `resolveWorkspaceFolder` was changed in last release which caused it not to return its input as a fallback. In the `createDocServer` code, `resolveWorkspaceFolder` was being called unnecessarily on an already resolved `targetPath` string. Just remove the call to fix the bug.

closes #76 

