### PR TITLE
fix: return better default in `resolveWorkspaceFolder`

### DIFF
--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -204,7 +204,10 @@ class Utils {
             window.showErrorMessage(`Workspace variable in path '${path}' could not be resolved.`);
         }
 
-        return {} as never;
+        return {
+            resolvedPath: "",
+            relativePath: "",
+        };
     }
 
     public static escapeRegExp(str: string): string {


### PR DESCRIPTION
the previous default did not consider the possibility that the
path may be empty and not match either of the regexes

closes #78 