### PR TITLE
fix: default source path bug

### DIFF
--- a/src/common/Settings.ts
+++ b/src/common/Settings.ts
@@ -150,10 +150,10 @@ class Settings {
 
         return !this.isDX(projectRoot) ? {
             relative: join(...legacyDefault),
-            resolved: resolve(projectRoot, ...legacyDefault),
+            resolved: resolve("${workspaceFolder}", ...legacyDefault),
         } : {
             relative: join(...dxDefault),
-            resolved: resolve(projectRoot, ...dxDefault),
+            resolved: resolve("${workspaceFolder}", ...dxDefault),
         }
     }
 


### PR DESCRIPTION
Fix bug where projects using default settings could not execute apexdox. The default source directory was an absolute path and did not use the `${workspaceFolder}` variable, which has been required since 6cb19e2.

fixes #80 
